### PR TITLE
[SERVIDOR CON ALIAS PARTE A][MGFJ][REDES] 

### DIFF
--- a/P4/PA/MGFJ/client.c
+++ b/P4/PA/MGFJ/client.c
@@ -1,0 +1,142 @@
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define CTRL_PORT 49200   // Puerto de control
+#define BUFSZ     4096    // Tamaño de buffer para envío
+
+// Escribe en status.log una línea con fecha, hora, estado, archivo y servidor.
+static void log_estado(const char *estado_linea, const char *server, int data_port, const char *file) {
+    time_t t = time(NULL);
+    struct tm *tm = localtime(&t);
+    char fecha[20], hora[20];
+    strftime(fecha, sizeof(fecha), "%F", tm);
+    strftime(hora,  sizeof(hora),  "%T", tm);
+
+    char estado[256];
+    snprintf(estado, sizeof(estado), "%s", estado_linea);
+    char *nl = strchr(estado, '\n');
+    if (nl) *nl = '\0';
+
+    FILE *f = fopen("status.log", "a");
+    if (!f) { perror("status.log"); return; }
+
+    fprintf(f, "%s | %s | %s | %s | %s:%d\n",
+            fecha, hora, estado, file, server, data_port);
+    fclose(f);
+}
+
+// Abre el socket y conecta a ip:port (acepta literal o alias en /etc/hosts).
+static int dial_ip(const char *ip, int port) {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) { perror("socket"); exit(1); }
+
+    struct sockaddr_in a; memset(&a, 0, sizeof(a));
+    a.sin_family = AF_INET;
+    a.sin_port   = htons(port);
+
+    if (inet_pton(AF_INET, ip, &a.sin_addr) != 1) {
+        a.sin_addr.s_addr = inet_addr(ip);
+        if (a.sin_addr.s_addr == INADDR_NONE) {
+            fprintf(stderr, "IP/host inválido: %s\n", ip);
+            exit(1);
+        }
+    }
+    if (connect(fd, (struct sockaddr*)&a, sizeof(a)) < 0) {
+        perror("connect"); exit(1);
+    }
+    return fd;
+}
+
+// Recibe una línea terminada en '\n' del socket fd y la guarda en buf.
+static ssize_t recv_line(int fd, char *buf, size_t cap) {
+    size_t i = 0;
+    while (i + 1 < cap) {
+        char c;
+        ssize_t r = recv(fd, &c, 1, 0);
+        if (r <= 0) return r;
+        buf[i++] = c;
+        if (c == '\n') break;
+    }
+    buf[i] = '\0';
+    return (ssize_t)i;
+}
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        fprintf(stderr, "Uso: %s <SERVER_IP|HOST> <ARCHIVO>\n", argv[0]);
+        return 1;
+    }
+    const char *server = argv[1];
+    const char *file   = argv[2];
+
+    // Paso 1: conectar al puerto de control y recibir "PORT X"
+    int cfd = dial_ip(server, CTRL_PORT);
+    char line[256];
+    ssize_t n = recv_line(cfd, line, sizeof(line));
+    if (n <= 0) {
+        fprintf(stderr, "No recibí puerto de datos\n");
+        close(cfd);
+        return 1;
+    }
+    close(cfd);
+
+    int data_port = 0;
+    if (sscanf(line, "PORT %d", &data_port) != 1 || data_port <= CTRL_PORT) {
+        fprintf(stderr, "Respuesta de control inválida: %s", line);
+        return 1;
+    }
+    fprintf(stderr, "[CLIENT] Puerto de datos asignado: %d\n", data_port);
+
+    // Paso 2: conectar al puerto de datos
+    int dfd = dial_ip(server, data_port);
+
+    // Paso 3: leer estados iniciales y registrarlos
+    for (int i = 0; i < 2; ++i) {
+        n = recv_line(dfd, line, sizeof(line));
+        if (n <= 0) {
+            fprintf(stderr, "Conexión cerrada antes de tiempo\n");
+            close(dfd);
+            return 1;
+        }
+        fputs(line, stdout);
+        log_estado(line, server, data_port, file);
+    }
+
+    // Paso 4: enviar archivo completo al servidor
+    FILE *fp = fopen(file, "rb");
+    if (!fp) {
+        perror("fopen");
+        close(dfd);
+        return 1;
+    }
+    char buf[BUFSZ]; size_t rn;
+    while ((rn = fread(buf, 1, sizeof(buf), fp)) > 0) {
+        ssize_t sent = send(dfd, buf, rn, 0);
+        if (sent < 0) {
+            perror("send");
+            fclose(fp);
+            close(dfd);
+            return 1;
+        }
+    }
+    fclose(fp);
+    shutdown(dfd, SHUT_WR);
+
+    // Paso 5: leer estados finales (TRANSMITIENDO, OK, etc.)
+    while ((n = recv_line(dfd, line, sizeof(line))) > 0) {
+        fputs(line, stdout);
+        log_estado(line, server, data_port, file);
+    }
+
+    close(dfd);
+    return 0;
+}

--- a/P4/PA/MGFJ/server.c
+++ b/P4/PA/MGFJ/server.c
@@ -1,0 +1,100 @@
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <errno.h>
+
+#define CTRL_PORT        49200     // Puerto de control
+#define FIRST_DATA_PORT  49201     // Primer puerto de datos
+#define BACKLOG          16        // Cola de conexiones
+#define BUFSZ            4096      // Tamaño de buffer para lectura
+
+// Crea socket, hace bind a (port, bind_ip) y pone a escuchar.
+static int bind_listen(int port, const char *bind_ip) {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) { perror("socket"); exit(1); }
+
+    int yes = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+
+    struct sockaddr_in a; memset(&a, 0, sizeof(a));
+    a.sin_family = AF_INET;
+    a.sin_port   = htons(port);
+    a.sin_addr.s_addr = bind_ip ? inet_addr(bind_ip) : htonl(INADDR_ANY);
+
+    if (bind(fd, (struct sockaddr*)&a, sizeof(a)) < 0) { perror("bind"); exit(1); }
+    if (listen(fd, BACKLOG) < 0) { perror("listen"); exit(1); }
+    return fd;
+}
+
+// Envía todo el contenido de la cadena s por el socket fd.
+static void send_all(int fd, const char *s) {
+    size_t n = strlen(s), off = 0;
+    while (off < n) {
+        ssize_t w = send(fd, s + off, n - off, 0);
+        if (w <= 0) { perror("send"); return; }
+        off += (size_t)w;
+    }
+}
+
+int main(int argc, char **argv) {
+    const char *BIND_IP = "192.168.0.1";           // IP local donde escuchar
+    int ctrl_fd = bind_listen(CTRL_PORT, BIND_IP); // Socket de control
+    fprintf(stderr, "[CTRL] Escuchando en %s:%d\n", BIND_IP ? BIND_IP : "0.0.0.0", CTRL_PORT);
+
+    int next_data_port = FIRST_DATA_PORT;          // Ronda de puertos de datos
+
+    for (;;) {
+        // Acepta conexión de control y anuncia puerto de datos.
+        struct sockaddr_in cli; socklen_t slen = sizeof(cli);
+        int cfd = accept(ctrl_fd, (struct sockaddr*)&cli, &slen);
+        if (cfd < 0) { perror("accept ctrl"); continue; }
+
+        int data_port = next_data_port++;
+        if (next_data_port > 65534 || next_data_port < FIRST_DATA_PORT)
+            next_data_port = FIRST_DATA_PORT;
+
+        char line[64];
+        snprintf(line, sizeof(line), "PORT %d\n", data_port);
+        send_all(cfd, line);
+        close(cfd);
+
+        // Abre el puerto de datos y atiende una sesión.
+        int data_fd = bind_listen(data_port, BIND_IP);
+        fprintf(stderr, "[DATA] Abierto puerto %d\n", data_port);
+
+        struct sockaddr_in dcli; socklen_t dlen = sizeof(dcli);
+        int d = accept(data_fd, (struct sockaddr*)&dcli, &dlen);
+        if (d < 0) { perror("accept data"); close(data_fd); continue; }
+
+        // Estados requeridos de la comunicación.
+        send_all(d, "EN_ESPERA\n");
+        send_all(d, "RECIBIENDO\n");
+
+        // Lee todo lo que envíe el cliente (simulación de recepción de archivo).
+        char buf[BUFSZ];
+        ssize_t r;
+        size_t total = 0;
+        while ((r = recv(d, buf, sizeof(buf), 0)) > 0) {
+            total += (size_t)r;
+        }
+
+        send_all(d, "TRANSMITIENDO\n");
+
+        // Respuesta final con estadística.
+        char ok[128];
+        snprintf(ok, sizeof(ok), "OK bytes_recibidos=%zu\n", total);
+        send_all(d, ok);
+
+        close(d);
+        close(data_fd);
+        fprintf(stderr, "[DATA] Sesión en %d terminada (bytes=%zu)\n", data_port, total);
+    }
+    return 0;
+}


### PR DESCRIPTION
Para esta parte de la práctica reutilicé parte de la lógica de la práctica anterior, aunque si tuve que modificar los archivos server.c y client.c para que tuvieran el comportamiento esperado de esta práctica, ahora como se pedía que el servidor no cerra la conexión y persistiera después de la comunicación con un cliente en un puerto superior, entonces el cliente ya no tiene que pasar el puerto, solo la ip del servidor y el archivo, y ahora el servidor después de realizar una comunicación cambia el puerto dinámicamente y lo asigna al cliente, además generando un archivo status.log donde se guarda todo el registro de la comunicación. Y el script de bash automatiza la ejecución del archivo client.c ya sea de manera indefinida o un cierto número de veces.

