### PR TITLE
[SERVIDOR CON ALIAS PARTE A][CCVM][REDES] 

### DIFF
--- a/P4/PA/CCVM/client.c
+++ b/P4/PA/CCVM/client.c
@@ -39,7 +39,6 @@ char* read_file(const char *filename, char *buffer, size_t buffer_size) {
 	return buffer;
 }
 
-
 void send_and_receive_message(int server_port, int client_sock, const char *filename) {
 	char file_buffer[BUFFER_SIZE * 10];
 	char recv_buffer[BUFFER_SIZE * 10];
@@ -111,12 +110,13 @@ char* get_ip(const char* alias) {
 
 int main(int argc, char *argv[]) {
 	if (argc <  3) {
-		printf("Type: %s <servidor_ip> <port> <archivo|s> \n", argv[0]);
+		printf("Type: %s <server_alias> <port> <archivo|s> \n", argv[0]);
 		return 1;
 	}
 	
 	char *server_ip = get_ip(argv[1]);
 	int port = atoi(argv[2]);
+
 	for (int i = 3; i < argc; i++) {
 		char *filename = argv[i];
 		printf("\n[*] Sending file: %s\n", filename);

--- a/P4/PA/CCVM/server.c
+++ b/P4/PA/CCVM/server.c
@@ -320,6 +320,7 @@ int main(int argc, char *argv[]) {
 		fprintf(stderr, "[-] Error: HOME environment variable not found.\n");
 		return 1;
 	}
+
 	snprintf(dir_path, sizeof(dir_path), "%s/%s", home_directory, alias);
 	printf("[!] The home directory of the server is: %s\n", dir_path); 
 


### PR DESCRIPTION
Para ambos archivos, tanto el cliente como el servidor esperan recibir el alias configurado en lugar de la ip como tal, ya que ambos tienen la misma función que obtiene la dirección ip en el código dado el alias. 

Tuve que hacer varios cambios a comparación de la práctica pasada, sobretodo en el servidor pues usaba poll, pero para hacer el proceso menos engorroso dada la cantidad de código que tenía, decidí mejor hacer esta práctica mediante fork. Ahora cada que hay una nueva conexión, se hace un proceso hijo con fork y se maneja con una función.