### PR TITLE
[SERVIDOR CON ALIAS PARTE B][SUC][REDES]

### DIFF
--- a/P4/PB/SUC/client.c
+++ b/P4/PB/SUC/client.c
@@ -1,0 +1,124 @@
+// PB client status: ejecuta consultas de estado a múltiples alias/hosts.
+// Uso: client <SELF_ALIAS> <ALIAS1> <ALIAS2> <ALIAS3>
+// Ejemplo: client s01 s02 s03 s04 (desde s01 consulta a s02, s03, s04).
+//
+// Protocolo (canal de control 49200):
+//   1) Conectar a <host>:49200 y enviar "ASSIGN\n".
+//   2) Recibir "PORT <p>\n".
+//   3) Conectarse a <host>:<p>, enviar "STATUS\n" y leer respuesta.
+// La salida agrega un timestamp y el host objetivo: "YYYY-MM-DD HH:MM:SS <host> <ESTADO>".
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define CONTROL_PORT 49200
+#define BUF 1024
+
+// Conecta a (host, port) usando getaddrinfo (IPv4/IPv6)
+static int connect_host_port(const char *host, int port) {
+    char portstr[16];
+    snprintf(portstr, sizeof(portstr), "%d", port);
+    struct addrinfo hints, *res = NULL, *rp = NULL;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    int err = getaddrinfo(host, portstr, &hints, &res);
+    if (err != 0) {
+        fprintf(stderr, "getaddrinfo %s: %s\n", host, gai_strerror(err));
+        return -1;
+    }
+    int fd = -1;
+    for (rp = res; rp; rp = rp->ai_next) {
+        fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (fd < 0) continue;
+        if (connect(fd, rp->ai_addr, rp->ai_addrlen) == 0) break;
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(res);
+    return fd;
+}
+
+// Lee una línea del socket (hasta '\n' o EOF)
+static int recv_line(int fd, char *buf, size_t max) {
+    size_t t = 0;
+    while (t + 1 < max) {
+        char c;
+        ssize_t r = recv(fd, &c, 1, 0);
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        if (r == 0) break;
+        buf[t++] = c;
+        if (c == '\n') break;
+    }
+    buf[t] = '\0';
+    return (int)t;
+}
+
+// Genera timestamp local "YYYY-MM-DD HH:MM:SS"
+static void now(char *out, size_t max) {
+    time_t t = time(NULL);
+    struct tm tm;
+    localtime_r(&t, &tm);
+    strftime(out, max, "%Y-%m-%d %H:%M:%S", &tm);
+}
+
+// Consulta el estado a un host: solicita puerto efímero y luego envía STATUS
+static void query_one(const char *self, const char *target) {
+    (void)self;
+    int cfd = connect_host_port(target, CONTROL_PORT);
+    if (cfd < 0) {
+        fprintf(stderr, "no connect %s\n", target);
+        return;
+    }
+    const char *assign = "ASSIGN\n";
+    send(cfd, assign, strlen(assign), 0);
+    char line[BUF];
+    if (recv_line(cfd, line, sizeof(line)) <= 0) {
+        close(cfd);
+        return;
+    }
+    int port = -1;
+    if (sscanf(line, "PORT %d", &port) != 1) {
+        close(cfd);
+        return;
+    }
+    close(cfd);
+
+    int dfd = connect_host_port(target, port);
+    if (dfd < 0) return;
+    const char *status = "STATUS\n";
+    send(dfd, status, strlen(status), 0);
+    if (recv_line(dfd, line, sizeof(line)) <= 0) {
+        close(dfd);
+        return;
+    }
+    close(dfd);
+    char ts[32];
+    now(ts, sizeof(ts));
+    printf("%s %s %s", ts, target, line);
+}
+
+int main(int argc, char *argv[]) {
+    if (argc != 5) {
+        fprintf(stderr, "Uso: %s <SELF_ALIAS> <ALIAS1> <ALIAS2> <ALIAS3>\n", argv[0]);
+        return 1;
+    }
+    const char *self = argv[1];
+    for (int i = 2; i < 5; i++) {
+        query_one(self, argv[i]);
+    }
+    return 0;
+}
+
+

--- a/P4/PB/SUC/server.c
+++ b/P4/PB/SUC/server.c
@@ -1,0 +1,185 @@
+// PB server: escucha en 49200 (INADDR_ANY) para todos los alias s01..s04
+// Asigna un puerto efímero por consulta (igual a Parte A) y responde STATUS.
+//
+// Protocolo de control (en 49200, líneas terminadas en \n):
+//   - "ASSIGN": el servidor crea un socket de datos en puerto efímero y contesta
+//       "PORT <numero>\n"; el cliente deberá conectarse a ese puerto y enviar "STATUS\n".
+//   - "SET WAITING" | "SET RECEIVING" | "SET SENDING": actualiza el estado interno
+//       (útil para pruebas). Responde "OK\n".
+//   - Otros comandos: responde "ERR\n".
+//
+// Protocolo de datos (en el puerto efímero):
+//   - Cliente envía "STATUS\n" y el servidor responde una sola línea:
+//       "WAITING\n" | "RECEIVING\n" | "SENDING\n".
+//
+// Nota: La escucha en múltiples alias/IP se logra a nivel del sistema con los alias
+// configurados; el servidor usa INADDR_ANY para atender en todas las direcciones.
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CONTROL_PORT 49200
+#define BACKLOG 64
+#define BUF 1024
+
+typedef enum { STATE_WAITING = 0, STATE_RECEIVING, STATE_SENDING } server_state_t;
+static server_state_t g_state = STATE_WAITING;
+
+// Crea un socket de escucha TCP en el puerto dado (IPv4, INADDR_ANY)
+static int create_listen(int port) {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        perror("socket");
+        return -1;
+    }
+    int yes = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = htons((uint16_t)port);
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        close(fd);
+        return -1;
+    }
+    if (listen(fd, BACKLOG) < 0) {
+        perror("listen");
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+// Lee una línea del socket (hasta '\n' o EOF), escribe en buffer con terminador '\0'
+static int recv_line(int fd, char *buffer, size_t maxlen) {
+    size_t total = 0;
+    while (total + 1 < maxlen) {
+        char c;
+        ssize_t r = recv(fd, &c, 1, 0);
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        if (r == 0) break;
+        buffer[total++] = c;
+        if (c == '\n') break;
+    }
+    buffer[total] = '\0';
+    return (int)total;
+}
+
+// Crea un socket de escucha en puerto efímero (bind a puerto 0) y lo devuelve
+static int assign_port(void) {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        perror("socket");
+        return -1;
+    }
+    int yes = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = htons(0);
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        close(fd);
+        return -1;
+    }
+    if (listen(fd, BACKLOG) < 0) {
+        perror("listen");
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+// Acepta una conexión en el puerto efímero y responde una única consulta STATUS
+static void serve_status_once(int data_fd) {
+    struct sockaddr_in cli;
+    socklen_t clilen = sizeof(cli);
+    int d = accept(data_fd, (struct sockaddr *)&cli, &clilen);
+    if (d < 0) {
+        perror("accept(data)");
+        close(data_fd);
+        return;
+    }
+    char line[BUF];
+    if (recv_line(d, line, sizeof(line)) > 0) {
+        if (strncmp(line, "STATUS", 6) == 0) {
+            const char *resp = "WAITING\n";
+            if (g_state == STATE_RECEIVING) resp = "RECEIVING\n";
+            else if (g_state == STATE_SENDING) resp = "SENDING\n";
+            send(d, resp, strlen(resp), 0);
+        }
+    }
+    close(d);
+    close(data_fd);
+}
+
+// Bucle principal del servidor de control (49200)
+int main(void) {
+    int ctrl = create_listen(CONTROL_PORT);
+    if (ctrl < 0) return 1;
+    printf("[PB server] listening 49200 on all aliases\n");
+    for (;;) {
+        struct sockaddr_in cli;
+        socklen_t clilen = sizeof(cli);
+        int s = accept(ctrl, (struct sockaddr *)&cli, &clilen);
+        if (s < 0) {
+            if (errno == EINTR) continue;
+            perror("accept");
+            break;
+        }
+        char line[BUF];
+        int n = recv_line(s, line, sizeof(line));
+        if (n <= 0) { close(s); continue; }
+        // Solicitud de asignación de puerto de datos
+        if (strncmp(line, "ASSIGN", 6) == 0) {
+            int dfd = assign_port();
+            if (dfd < 0) { close(s); continue; }
+            struct sockaddr_in la; socklen_t ll = sizeof(la);
+            getsockname(dfd, (struct sockaddr *)&la, &ll);
+            int port = ntohs(la.sin_port);
+            char resp[64];
+            int m = snprintf(resp, sizeof(resp), "PORT %d\n", port);
+            send(s, resp, (size_t)m, 0);
+            close(s);
+            serve_status_once(dfd);
+        // Cambios de estado para pruebas
+        } else if (strncmp(line, "SET WAITING", 11) == 0) {
+            g_state = STATE_WAITING;
+            const char *ok = "OK\n";
+            send(s, ok, strlen(ok), 0);
+            close(s);
+        } else if (strncmp(line, "SET RECEIVING", 13) == 0) {
+            g_state = STATE_RECEIVING;
+            const char *ok = "OK\n";
+            send(s, ok, strlen(ok), 0);
+            close(s);
+        } else if (strncmp(line, "SET SENDING", 11) == 0) {
+            g_state = STATE_SENDING;
+            const char *ok = "OK\n";
+            send(s, ok, strlen(ok), 0);
+            close(s);
+        } else {
+            const char *bad = "ERR\n";
+            send(s, bad, strlen(bad), 0);
+            close(s);
+        }
+    }
+    close(ctrl);
+    return 0;
+}
+
+


### PR DESCRIPTION
Para la Parte B implementé un servidor que escucha en 49200 para todos los alias (s01, s02, s03, s04) y un cliente de “status” que, desde cada alias, consulta a los demás, el servidor asigna un puerto efímero por consulta y responde al comando STATUS, y el cliente imprime “YYYY-MM-DD HH:MM:SS <host> <ESTADO>”. Lo que más me costó fue coordinar las consultas multi-alias y mantener el protocolo (control en 49200 + puerto efímero) simple y estable, aprendí a usar INADDR_ANY para atender todas las IP del host, a resolver alias con /etc/hosts y a obtener puertos efímeros con bind a 0 y getsockname.